### PR TITLE
Use image's actual contents to derive filename

### DIFF
--- a/src/remote_decks/libs/org_to_anki/config.py
+++ b/src/remote_decks/libs/org_to_anki/config.py
@@ -8,4 +8,3 @@ quickNotesDirectory = homePath + "/orgNotes"
 rootDeck = "Remote decks" # XXX this should be set elsewhere so this has no effect, but it currently has
 defaultDeckConnector = "::"
 defaultAnkiConnectAddress = "http://127.0.0.1:8765/"
-lazyLoadImages=False

--- a/src/remote_decks/libs/org_to_anki/org_parser/NoteFactoryUtils.py
+++ b/src/remote_decks/libs/org_to_anki/org_parser/NoteFactoryUtils.py
@@ -18,8 +18,9 @@ class NoteFactoryUtils:
             url_sections = re.findall(image_re, line)
             for url_section in url_sections:
                 url, height, width = url_section
-                image_name = f"img_{hashlib.md5(url.encode()).hexdigest()}"
-                note.addLazyImage(image_name, url, getImageFromUrl)
+                image_data = getImageFromUrl(url)
+                image_name = f"img_{hashlib.md5(image_data).hexdigest()}"
+                note.addImage(image_name, image_data)
 
                 image_html = f'<img src="{image_name}" height={height} width={width} />'
                 result = re.sub("\[image=[^]]+?\]", image_html, result, count=1)

--- a/src/remote_decks/libs/org_to_anki/org_parser/NoteFactoryUtils.py
+++ b/src/remote_decks/libs/org_to_anki/org_parser/NoteFactoryUtils.py
@@ -6,10 +6,6 @@ from .ParserUtils import getImageFromUrl
 
 
 class NoteFactoryUtils:
-    def __init__(self):
-
-        self.lazyLoadImages = config.lazyLoadImages
-
     def substitute_img_tags(self, line, note):
         result = line
 

--- a/src/remote_decks/parse_remote_deck.py
+++ b/src/remote_decks/parse_remote_deck.py
@@ -48,8 +48,6 @@ def _parseHtmlPageToAnkiDeck(data):
     deckName = orgData["deckName"]
     lines = orgData["data"]
 
-    # Ensure images are lazy loaded to reduce load
-    config.lazyLoadImages = True
     deck = build_deck_from_org_lines(lines, deckName)
 
     return deck


### PR DESCRIPTION
Google Docs can serve an image from a different URL without the image changing at all, so using the URL to derive a filename appears to be unreliable. Should fix #5